### PR TITLE
increase read timeout

### DIFF
--- a/packages/tss-client/src/client.ts
+++ b/packages/tss-client/src/client.ts
@@ -43,9 +43,13 @@ if (globalThis.js_read_msg === undefined) {
             clearInterval(timer);
             resolve(found.msg_data);
           }
-          if (counter >= 500) {
+          if (counter >= 3000) {
             clearInterval(timer);
-            reject(new Error("Message not received in a reasonable time"));
+            // TODO Fix wasm to handle error objects properly and then reject
+            // with Error instead of string.
+            //
+            // eslint-disable-next-line prefer-promise-reject-errors
+            reject("Message not received in a reasonable time");
           }
           counter++;
         }, 10);

--- a/packages/tss-client/src/client.ts
+++ b/packages/tss-client/src/client.ts
@@ -43,7 +43,7 @@ if (globalThis.js_read_msg === undefined) {
             clearInterval(timer);
             resolve(found.msg_data);
           }
-          if (counter >= 3000) {
+          if (counter >= 1000) {
             clearInterval(timer);
             // TODO Fix wasm to handle error objects properly and then reject
             // with Error instead of string.


### PR DESCRIPTION
The read message timeout was at 5 seconds.
This can cause timeouts on a slow network connection.
Here we propose to increase the read timeout to 30 seconds.