### PR TITLE
package dkls types with client lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@types/elliptic": "^6.4.16",
         "babel-loader": "^9.1.3",
         "chromedriver": "^124.0.1",
-        "copy-webpack-plugin": "^11.0.0",
         "find-process": "^1.4.7",
         "husky": "^8.0.3",
         "lerna": "^8.0.2",
@@ -8988,77 +8987,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/copy-webpack-plugin": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
-      "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "^3.2.11",
-        "glob-parent": "^6.0.1",
-        "globby": "^13.1.1",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.37.1",
@@ -24599,7 +24527,6 @@
         "@types/jsrsasign": "^10.5.12",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "copy-webpack-plugin": "^11.0.0",
         "crypto-browserify": "^3.12.0",
         "html-webpack-plugin": "^5.5.0",
         "https-browserify": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@toruslabs/torus-scripts": "^5.3.1",
         "@types/elliptic": "^6.4.16",
         "babel-loader": "^9.1.3",
-        "chromedriver": "^124.0.1",
+        "chromedriver": "^126.0.1",
         "find-process": "^1.4.7",
         "husky": "^8.0.3",
         "lerna": "^8.0.2",
@@ -8293,11 +8293,12 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "124.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-124.0.3.tgz",
-      "integrity": "sha512-k6Xu9fwDMgi//bGHB944QMmDHF0BBWGk4PAyVZBEuP6wnZMfQP4V6Sv+l/nuAPA006RllS6X07ZpjPwRPS4BaA==",
+      "version": "126.0.4",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.4.tgz",
+      "integrity": "sha512-mIdJqdocfN/y9fl5BymIzM9WQLy64x078i5tS1jGFzbFAwXwXrj3zmA86Wf3R/hywPYpWqwXxFGBJHgqZTuGCA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
         "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/elliptic": "^6.4.16",
     "babel-loader": "^9.1.3",
     "chromedriver": "^124.0.1",
-    "copy-webpack-plugin": "^11.0.0",
     "find-process": "^1.4.7",
     "husky": "^8.0.3",
     "lerna": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@toruslabs/torus-scripts": "^5.3.1",
     "@types/elliptic": "^6.4.16",
     "babel-loader": "^9.1.3",
-    "chromedriver": "^124.0.1",
+    "chromedriver": "^126.0.1",
     "find-process": "^1.4.7",
     "husky": "^8.0.3",
     "lerna": "^8.0.2",

--- a/packages/tss-client/src/client.ts
+++ b/packages/tss-client/src/client.ts
@@ -113,7 +113,7 @@ export class Client {
 
   public websocketOnly: boolean;
 
-  public tssLib: TssLib;
+  public tssLib: typeof TssLib;
 
   public _startPrecomputeTime: number;
 
@@ -154,7 +154,7 @@ export class Client {
     _share: string,
     _pubKey: string,
     _websocketOnly: boolean,
-    _tssLib: TssLib
+    _tssLib: typeof TssLib
   ) {
     if (_parties.length !== _sockets.length) {
       throw new Error("parties and sockets length must be equal, add null for client if necessary");

--- a/packages/tss-client/tsconfig.json
+++ b/packages/tss-client/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "include": ["./src/**/*"],
 }

--- a/packages/tss-lib/.eslintrc.json
+++ b/packages/tss-lib/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../.eslintrc"],
+  "extends": ["../../.eslintrc.js"],
   "parserOptions": {
     "project": "./tsconfig.json"
   }

--- a/packages/tss-lib/src/index.ts
+++ b/packages/tss-lib/src/index.ts
@@ -1,4 +1,4 @@
-import * as lib from "./pkg";
+import * as lib from "./pkg/dkls";
 import wasmDataURL from "./pkg/dkls_bg.wasm";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/tss-lib/tsconfig.json
+++ b/packages/tss-lib/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "exclude": ["*.d.ts"],
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/*"],
 }

--- a/packages/tss-lib/webpack.config.js
+++ b/packages/tss-lib/webpack.config.js
@@ -1,13 +1,4 @@
-const CopyPlugin = require("copy-webpack-plugin");
-
 const cfg = {
-  plugins: [
-    new CopyPlugin({
-      patterns: [
-        { from: "src/pkg/dkls.d.ts", to: "types/dkls.d.ts" }
-      ]
-    })
-  ],
   module: {
     rules: [
       {

--- a/packages/web-example/package.json
+++ b/packages/web-example/package.json
@@ -42,7 +42,6 @@
         "@types/jsrsasign": "^10.5.12",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "copy-webpack-plugin": "^11.0.0",
         "crypto-browserify": "^3.12.0",
         "html-webpack-plugin": "^5.5.0",
         "https-browserify": "^1.0.0",

--- a/packages/web-example/webpack.config.js
+++ b/packages/web-example/webpack.config.js
@@ -1,8 +1,8 @@
 const path = require("path");
 const webpack = require("webpack");
 
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const CopyPlugin = require("copy-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
 /** @type {import("webpack").Configuration} */
 module.exports = {
   entry: process.env.NODE_ENV === "local" || process.env.NODE_ENV === "development" || process.env.NODE_ENV === "testing" ? "./src/local.ts" : "./src/prod.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@toruslabs/config/tsconfig.default.json",
   "compilerOptions": {
     "baseUrl": "./",
+    "allowJs": true,
+    "skipLibCheck": true,
     "paths": {
       "@toruslabs/*": ["packages/tss-*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "allowJs": true,
-    "skipLibCheck": true,
     "paths": {
       "@toruslabs/*": ["packages/tss-*"]
     }


### PR DESCRIPTION
The new tss-lib did not package the lib types correctly. As a result, the `dkls.d.ts` file was not included in the `dist` folder. This PR fixes that.